### PR TITLE
feat(books): Integrate Google Books API for external book import

### DIFF
--- a/src/main/java/com/eduardoxduardo/vlibrary/client/BooksClient.java
+++ b/src/main/java/com/eduardoxduardo/vlibrary/client/BooksClient.java
@@ -1,0 +1,10 @@
+package com.eduardoxduardo.vlibrary.client;
+
+import com.eduardoxduardo.vlibrary.dto.response.BookExternalResponseDTO;
+
+import java.util.List;
+
+public interface BooksClient {
+    List<BookExternalResponseDTO> searchBooksByTitle(String title);
+    BookExternalResponseDTO findBookById(String apiId);
+}

--- a/src/main/java/com/eduardoxduardo/vlibrary/client/impl/GoogleBooksClient.java
+++ b/src/main/java/com/eduardoxduardo/vlibrary/client/impl/GoogleBooksClient.java
@@ -1,0 +1,91 @@
+package com.eduardoxduardo.vlibrary.client.impl;
+
+import com.eduardoxduardo.vlibrary.client.BooksClient;
+import com.eduardoxduardo.vlibrary.dto.google.GoogleApiResponse;
+import com.eduardoxduardo.vlibrary.dto.google.GoogleBookItem;
+import com.eduardoxduardo.vlibrary.dto.google.VolumeInfo;
+import com.eduardoxduardo.vlibrary.dto.response.BookExternalResponseDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+public class GoogleBooksClient implements BooksClient {
+
+    private final RestTemplate restTemplate;
+
+    private final String apiKey;
+
+    private static final String GOOGLE_API_URL = "https://www.googleapis.com/books/v1/volumes";
+
+    public GoogleBooksClient (RestTemplate restTemplate, @Value("${google.api.key}") String apiKey) {
+        this.restTemplate = restTemplate;
+        this.apiKey = apiKey;
+    }
+
+    @Override
+    public List<BookExternalResponseDTO> searchBooksByTitle(String title) {
+        String url = UriComponentsBuilder.fromUriString(GOOGLE_API_URL)
+                .queryParam("q", "intitle:" + title)
+                .queryParam("key", apiKey)
+                .queryParam("maxResults", 10)
+                .queryParam("projection", "lite")
+                .toUriString();
+
+        try {
+            GoogleApiResponse response = restTemplate.getForObject(url, GoogleApiResponse.class);
+
+            if (response == null || response.getItems() == null) {
+                return Collections.emptyList();
+            }
+
+            return response.getItems().stream()
+                    .filter(Objects::nonNull)
+                    .map(this::convertToExternalDTO)
+                    .collect(Collectors.toList());
+
+        } catch (Exception e) {
+            System.err.println("Error fetching books from Google API: " + e.getMessage());
+            return Collections.emptyList();
+        }    
+    }
+
+    @Override
+    public BookExternalResponseDTO findBookById(String apiId) {
+        String url = UriComponentsBuilder.fromUriString(GOOGLE_API_URL + "/" + apiId)
+                .queryParam("key", apiKey)
+                .toUriString();
+
+        try {
+            GoogleBookItem item = restTemplate.getForObject(url, GoogleBookItem.class);
+            if (item == null) {
+                return null;
+            }
+            return convertToExternalDTO(item);
+        } catch (Exception e) {
+            System.err.println("Error fetching book by ID from Google API: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private BookExternalResponseDTO convertToExternalDTO(GoogleBookItem item) {
+        VolumeInfo info = item.getVolumeInfo();
+        if (info == null) {
+            return null;
+        }
+
+        return new BookExternalResponseDTO(
+                item.getId(),
+                info.getTitle(),
+                info.getAuthors() != null ? info.getAuthors() : Collections.emptyList(),
+                info.getDescription(),
+                info.getCategories() != null ? info.getCategories() : Collections.emptyList()
+        );
+    }
+}

--- a/src/main/java/com/eduardoxduardo/vlibrary/client/impl/GoogleBooksClient.java
+++ b/src/main/java/com/eduardoxduardo/vlibrary/client/impl/GoogleBooksClient.java
@@ -68,8 +68,14 @@ public class GoogleBooksClient implements BooksClient {
                 return null;
             }
             return convertToExternalDTO(item);
-        } catch (Exception e) {
-            System.err.println("Error fetching book by ID from Google API: " + e.getMessage());
+        } catch (HttpClientErrorException e) {
+            System.err.println("HTTP error while fetching book by ID from Google API: " + e.getMessage());
+            return null;
+        } catch (ResourceAccessException e) {
+            System.err.println("Connection error while accessing Google API: " + e.getMessage());
+            return null;
+        } catch (RestClientException e) {
+            System.err.println("Unexpected error while fetching book by ID from Google API: " + e.getMessage());
             return null;
         }
     }

--- a/src/main/java/com/eduardoxduardo/vlibrary/config/ApplicationConfig.java
+++ b/src/main/java/com/eduardoxduardo/vlibrary/config/ApplicationConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -22,6 +23,11 @@ import java.util.List;
 public class ApplicationConfig {
 
     private final UserRepository userRepository;
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
 
     @Bean
     public UserDetailsService userDetailsService() {

--- a/src/main/java/com/eduardoxduardo/vlibrary/controller/BookController.java
+++ b/src/main/java/com/eduardoxduardo/vlibrary/controller/BookController.java
@@ -3,6 +3,7 @@ package com.eduardoxduardo.vlibrary.controller;
 import com.eduardoxduardo.vlibrary.dto.filter.BookSearchCriteria;
 import com.eduardoxduardo.vlibrary.dto.request.create.BookCreateRequestDTO;
 import com.eduardoxduardo.vlibrary.dto.request.update.BookUpdateRequestDTO;
+import com.eduardoxduardo.vlibrary.dto.response.BookExternalResponseDTO;
 import com.eduardoxduardo.vlibrary.dto.response.BookResponseDTO;
 import com.eduardoxduardo.vlibrary.service.BookService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -22,6 +23,7 @@ public class BookController {
 
     private final BookService bookService;
 
+    // Endpoint to create a new book manually if it does not exist in the book api
     @PostMapping
     public ResponseEntity<BookResponseDTO> createBook(@Valid @RequestBody BookCreateRequestDTO request) {
         return ResponseEntity.status(201).body(bookService.createBook(request));
@@ -56,5 +58,16 @@ public class BookController {
     public ResponseEntity<Void> deleteBook(@PathVariable Long id) {
         bookService.deleteBook(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/external/{apiId}")
+    public ResponseEntity<BookResponseDTO> importBookFromApi(@PathVariable String apiId) {
+        return ResponseEntity.status(201).body(bookService.findOrCreateBookFromApi(apiId));
+    }
+
+    @GetMapping("/external")
+    public ResponseEntity<List<BookExternalResponseDTO>> searchExternalBooks(@RequestParam String title) {
+        List<BookExternalResponseDTO> books = bookService.searchExternalBooksFromApi(title);
+        return ResponseEntity.ok(books);
     }
 }

--- a/src/main/java/com/eduardoxduardo/vlibrary/dto/google/GoogleApiResponse.java
+++ b/src/main/java/com/eduardoxduardo/vlibrary/dto/google/GoogleApiResponse.java
@@ -1,0 +1,16 @@
+package com.eduardoxduardo.vlibrary.dto.google;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GoogleApiResponse {
+
+    private List<GoogleBookItem> items;
+
+}

--- a/src/main/java/com/eduardoxduardo/vlibrary/dto/google/GoogleBookItem.java
+++ b/src/main/java/com/eduardoxduardo/vlibrary/dto/google/GoogleBookItem.java
@@ -1,0 +1,15 @@
+package com.eduardoxduardo.vlibrary.dto.google;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GoogleBookItem {
+
+    private String id;
+    private VolumeInfo volumeInfo;
+
+}

--- a/src/main/java/com/eduardoxduardo/vlibrary/dto/google/VolumeInfo.java
+++ b/src/main/java/com/eduardoxduardo/vlibrary/dto/google/VolumeInfo.java
@@ -1,0 +1,18 @@
+package com.eduardoxduardo.vlibrary.dto.google;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VolumeInfo {
+
+    private String title;
+    private List<String> authors;
+    private String description;
+    private List<String> categories;
+}

--- a/src/main/java/com/eduardoxduardo/vlibrary/dto/response/BookExternalResponseDTO.java
+++ b/src/main/java/com/eduardoxduardo/vlibrary/dto/response/BookExternalResponseDTO.java
@@ -1,0 +1,18 @@
+package com.eduardoxduardo.vlibrary.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BookExternalResponseDTO {
+    String apiId;
+    String title;
+    List<String> authors;
+    String description;
+    List<String> categories;
+}

--- a/src/main/java/com/eduardoxduardo/vlibrary/model/entities/Book.java
+++ b/src/main/java/com/eduardoxduardo/vlibrary/model/entities/Book.java
@@ -21,9 +21,17 @@ public class Book implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    // Only null if the book is not from Google Books API
+    @Column(unique = true)
+    private String googleApiId;
+
     private String title;
+
+    @Column(columnDefinition = "TEXT")
     private String description;
 
+    // TODO: books can have multiple authors
     @ManyToOne
     @JoinColumn(name = "author_id", nullable = false)
     private Author author;
@@ -39,7 +47,8 @@ public class Book implements Serializable {
     )
     private Set<Genre> genres;
 
-    public Book(String title, Author author) {
+    public Book(String googleApiId, String title, Author author) {
+        this.googleApiId = googleApiId;
         this.title = title;
         this.author = author;
     }

--- a/src/main/java/com/eduardoxduardo/vlibrary/repository/AuthorRepository.java
+++ b/src/main/java/com/eduardoxduardo/vlibrary/repository/AuthorRepository.java
@@ -5,7 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AuthorRepository extends JpaRepository<Author, Long>, JpaSpecificationExecutor<Author> {
     Boolean existsByBooks_AuthorId(Long authorId);
+
+    Optional<Author> findByName(String authorName);
 }

--- a/src/main/java/com/eduardoxduardo/vlibrary/repository/BookRepository.java
+++ b/src/main/java/com/eduardoxduardo/vlibrary/repository/BookRepository.java
@@ -6,9 +6,11 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface BookRepository extends JpaRepository<Book, Long>, JpaSpecificationExecutor<Book> {
     List<Book> findByGenresId(Long genreId);
     Boolean existsByUserEntries_BookId(Long bookId);
+    Optional<Book> findByGoogleApiId(String apiId);
 }

--- a/src/main/java/com/eduardoxduardo/vlibrary/repository/GenreRepository.java
+++ b/src/main/java/com/eduardoxduardo/vlibrary/repository/GenreRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface GenreRepository extends JpaRepository<Genre, Long>, JpaSpecificationExecutor<Genre> {
+    Optional<Genre> findByName(String categoryName);
 }

--- a/src/main/java/com/eduardoxduardo/vlibrary/service/BookService.java
+++ b/src/main/java/com/eduardoxduardo/vlibrary/service/BookService.java
@@ -176,7 +176,7 @@ public class BookService {
         // Check if the author is provided and handle "Find or Create"
         // For now, we assume the first author is the main one
         // TODO: Handle multiple authors
-        if (externalBook.getAuthors() != null && !externalBook.getAuthors().isEmpty()) {
+        if (!externalBook.getAuthors().isEmpty()) {
             String authorName = externalBook.getAuthors().getFirst();
             Author author = authorRepository.findByName(authorName)
                     .orElseGet(() -> authorRepository.save(new Author(authorName)));

--- a/src/main/resources/application.properties.example
+++ b/src/main/resources/application.properties.example
@@ -12,3 +12,5 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
 app.jwt.secret=(Insert here your JWT secret password)
+
+google.api.key=(Insert here your Google API key)


### PR DESCRIPTION
- Added BooksClient interface and GoogleBooksClient implementation to fetch book data from Google Books API. - Introduced DTOs for Google API responses and external book data.
- Updated Book entity to support Google API IDs and adjusted repositories for author and genre lookup by name.
- BookService and BookController now support searching and importing books from the external API, with endpoints for these operations.
- Updated application config to provide RestTemplate and added Google API key property example.